### PR TITLE
Updated get_user for github API v3

### DIFF
--- a/github-growler.pl
+++ b/github-growler.pl
@@ -258,14 +258,12 @@ sub get_user {
     $Cache->("user:$name", sub {
         my $cb = shift;
 
-        http_get "http://github.com/api/v2/json/user/show/$name", persistent => 0, sub {
+        http_get "https://api.github.com/users/$name", persistent => 0, sub {
             if ($_[1]->{Status} == 200) {
                 my $content = JSON::decode_json($_[0]);
                 $cb->({
-                    name   => $content->{user}->{name},
-                    avatar => "https://secure.gravatar.com/avatar/"
-                      . $content->{user}->{gravatar_id}
-                      . "?s=140&d=https://d3nwyuy0nl342s.cloudfront.net%2Fimages%2Fgravatars%2Fgravatar-140.png",
+                    name   => $content->{name},
+                    avatar => $content->{avatar_url},
                 });
             } else {
                 $cb->({});


### PR DESCRIPTION
The invocation of github API in get_user function is failed because github API v2 is obsoleted. This patch is to use github API v3.
